### PR TITLE
Instance type filtering

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,15 +22,6 @@ function loadConfig() {
   return config;
 }
 
-function loadDefaults() {
-  const defaults = nconf.get('defaults') || {};
-  debug( 'Validating defaults...' );
-  const errors = tfhooks.validateConfig( defaults );
-  if( errors ) throw { message : 'Default configuration errors', errors };
-  module.exports.defaults = defaults;
-  return defaults;
-}
-
 function *loadApply() {
   let inputApply = null;
   let apply = new TFApply();
@@ -79,19 +70,18 @@ module.exports.main = function *main( testParams ) {
   debug( 'NO_PROXY %s', process.env[ 'NO_PROXY' ] );
   debug( 'HTTP_PROXY %s', process.env[ 'HTTP_PROXY' ] );
   debug( 'HTTPS_PROXY %s', process.env[ 'HTTPS_PROXY' ] );
-
+  
   nconf.argv().env().file( { file: 'terraform.tfhooks', format: nconfyaml } ).overrides( testParams );
 
   const config  = loadConfig();
-  const defaults = loadDefaults();
   const apply   = yield loadApply();
   const state   = loadState();
 
   let results = [];
-
+  
   if( nconf.get( 'dryRun' ) != true ) {
     debug( 'Running hooks...' );
-    results = yield tfhooks.runHooks( { config, defaults, apply, state } );
+    results = yield tfhooks.runHooks( { config, apply, state } );
   }
   return results;
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,15 @@ function loadConfig() {
   return config;
 }
 
+function loadDefaults() {
+  const defaults = nconf.get('defaults') || {};
+  debug( 'Validating defaults...' );
+  const errors = tfhooks.validateConfig( defaults );
+  if( errors ) throw { message : 'Default configuration errors', errors };
+  module.exports.defaults = defaults;
+  return defaults;
+}
+
 function *loadApply() {
   let inputApply = null;
   let apply = new TFApply();
@@ -70,18 +79,19 @@ module.exports.main = function *main( testParams ) {
   debug( 'NO_PROXY %s', process.env[ 'NO_PROXY' ] );
   debug( 'HTTP_PROXY %s', process.env[ 'HTTP_PROXY' ] );
   debug( 'HTTPS_PROXY %s', process.env[ 'HTTPS_PROXY' ] );
-  
+
   nconf.argv().env().file( { file: 'terraform.tfhooks', format: nconfyaml } ).overrides( testParams );
 
   const config  = loadConfig();
+  const defaults = loadDefaults();
   const apply   = yield loadApply();
   const state   = loadState();
 
   let results = [];
-  
+
   if( nconf.get( 'dryRun' ) != true ) {
     debug( 'Running hooks...' );
-    results = yield tfhooks.runHooks( { config, apply, state } );
+    results = yield tfhooks.runHooks( { config, defaults, apply, state } );
   }
   return results;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,36 +43,18 @@ module.exports.runHooks = function *runHooks( params ) {
   let types = _.keys( params.config );
   for( let type of _.keys( params.apply.add ) ) {
     debug( 'Type %s ', type );
-
-    var config;
-    var actions;
-    if(types.length) {
-      // if the config specifies any types explicitly, only use those
-      if( types.indexOf( type ) > -1 ) {
-        config = params.config[ type ];
-        actions = _.get( config, 'actions', [ 'add' ] );
-        delete config[ 'actions' ];
-      } else {
-        // if the given type is not configured, skip it
-        continue;
+    if( types.indexOf( type ) > -1 ) {
+      let config = params.config[ type ];
+      let actions = _.get( config, 'actions', [ 'add' ] );
+      delete config[ 'actions' ];
+      for( let action of actions ) {
+        let instanceNames = _.keys( params.apply[ action ][ type ] );
+        let instances = _.reduce( instanceNames, ( accum, name ) => {
+          accum[ name ] = _.get( params.state.resource, `${type}.${name}` );
+          return accum;
+        }, {} );
+        results = results.concat( yield batchHook( action, type, instances, config ) );
       }
-    } else {
-      // otherwise we're processing all the types
-      actions = _.get( params.defaults, 'actions', [ 'add' ] );
-      config = {};
-    }
-
-    if(!config.target) {
-      config.target = params.defaults.target;
-    }
-
-    for( let action of actions ) {
-      let instanceNames = _.keys( params.apply[ action ][ type ] );
-      let instances = _.reduce( instanceNames, ( accum, name ) => {
-        accum[ name ] = _.get( params.state.resource, `${type}.${name}` );
-        return accum;
-      }, {} );
-      results = results.concat( yield batchHook( action, type, instances, config ) );
     }
   }
   return results;

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,18 +43,36 @@ module.exports.runHooks = function *runHooks( params ) {
   let types = _.keys( params.config );
   for( let type of _.keys( params.apply.add ) ) {
     debug( 'Type %s ', type );
-    if( types.indexOf( type ) > -1 ) {
-      let config = params.config[ type ];
-      let actions = _.get( config, 'actions', [ 'add' ] );
-      delete config[ 'actions' ];
-      for( let action of actions ) {
-        let instanceNames = _.keys( params.apply[ action ][ type ] );
-        let instances = _.reduce( instanceNames, ( accum, name ) => {
-          accum[ name ] = _.get( params.state.resource, `${type}.${name}` );
-          return accum;
-        }, {} );
-        results = results.concat( yield batchHook( action, type, instances, config ) );
+
+    var config;
+    var actions;
+    if(types.length) {
+      // if the config specifies any types explicitly, only use those
+      if( types.indexOf( type ) > -1 ) {
+        config = params.config[ type ];
+        actions = _.get( config, 'actions', [ 'add' ] );
+        delete config[ 'actions' ];
+      } else {
+        // if the given type is not configured, skip it
+        continue;
       }
+    } else {
+      // otherwise we're processing all the types
+      actions = _.get( params.defaults, 'actions', [ 'add' ] );
+      config = {};
+    }
+
+    if(!config.target) {
+      config.target = params.defaults.target;
+    }
+
+    for( let action of actions ) {
+      let instanceNames = _.keys( params.apply[ action ][ type ] );
+      let instances = _.reduce( instanceNames, ( accum, name ) => {
+        accum[ name ] = _.get( params.state.resource, `${type}.${name}` );
+        return accum;
+      }, {} );
+      results = results.concat( yield batchHook( action, type, instances, config ) );
     }
   }
   return results;

--- a/lib/schema.yml
+++ b/lib/schema.yml
@@ -1,5 +1,11 @@
 type : object
 properties :
+  defaults :
+    type : object
+    properties :
+      target:
+        type : string
+        format : uri
   hooks :
     type : object
     properties :

--- a/lib/schema.yml
+++ b/lib/schema.yml
@@ -1,11 +1,5 @@
 type : object
 properties :
-  defaults :
-    type : object
-    properties :
-      target:
-        type : string
-        format : uri
   hooks :
     type : object
     properties :

--- a/terraform.tfhooks
+++ b/terraform.tfhooks
@@ -1,5 +1,7 @@
-hooks :
-  aws_db_instance :
-    actions :
-      - add
-    target : http://requestb.in/744iitu1
+defaults :
+  target : http://requestb.in/744iitu1
+#hooks :
+#  aws_db_instance :
+#    actions :
+#      - add
+#    target : http://requestb.in/744iitu1

--- a/terraform.tfhooks
+++ b/terraform.tfhooks
@@ -1,7 +1,5 @@
-defaults :
-  target : http://requestb.in/744iitu1
-#hooks :
-#  aws_db_instance :
-#    actions :
-#      - add
-#    target : http://requestb.in/744iitu1
+hooks :
+  aws_db_instance :
+    actions :
+      - add
+    target : http://requestb.in/744iitu1


### PR DESCRIPTION
Added ability to not apply filtering and send all the instance types (though technically we may want to rename those to "elements" or "data" at some point, including the CF hook endpoint name